### PR TITLE
Refactor View and ViewModel layers for stricter Clean Architecture

### DIFF
--- a/common/src/main/java/xyz/androidrey/githubclient/common/domain/model/DomainResult.kt
+++ b/common/src/main/java/xyz/androidrey/githubclient/common/domain/model/DomainResult.kt
@@ -1,0 +1,6 @@
+package xyz.androidrey.githubclient.common.domain.model
+
+sealed class DomainResult<out T> {
+    data class Success<out T>(val data: T) : DomainResult<T>()
+    data class Error(val message: String) : DomainResult<Nothing>()
+}

--- a/features/main/src/main/java/xyz/androidrey/githubclient/main/domain/usecase/repository/GetRepositoryUseCase.kt
+++ b/features/main/src/main/java/xyz/androidrey/githubclient/main/domain/usecase/repository/GetRepositoryUseCase.kt
@@ -1,11 +1,16 @@
 package xyz.androidrey.githubclient.main.domain.usecase.repository
 
 import xyz.androidrey.githubclient.common.data.entity.repository.Repository
+import xyz.androidrey.githubclient.common.domain.model.DomainResult
 import xyz.androidrey.githubclient.main.domain.repository.MainRepository
 import xyz.androidrey.githubclient.network.NetworkResult
 import javax.inject.Inject
 
 class GetRepositoryUseCase @Inject constructor(private val repository: MainRepository) {
-    suspend operator fun invoke(userName: String): NetworkResult<List<Repository>> =
-        repository.getRepository(userName)
+    suspend operator fun invoke(userName: String): DomainResult<List<Repository>> {
+        return when (val networkResult = repository.getRepository(userName)) {
+            is NetworkResult.Success -> DomainResult.Success(networkResult.result)
+            is NetworkResult.Error -> DomainResult.Error(networkResult.exception.message ?: "Unknown error")
+        }
+    }
 }

--- a/features/main/src/main/java/xyz/androidrey/githubclient/main/domain/usecase/users/GetUserDetailsUseCase.kt
+++ b/features/main/src/main/java/xyz/androidrey/githubclient/main/domain/usecase/users/GetUserDetailsUseCase.kt
@@ -1,11 +1,16 @@
 package xyz.androidrey.githubclient.main.domain.usecase.users
 
 import xyz.androidrey.githubclient.common.data.entity.githubuser.GithubUser
+import xyz.androidrey.githubclient.common.domain.model.DomainResult
 import xyz.androidrey.githubclient.main.domain.repository.MainRepository
 import xyz.androidrey.githubclient.network.NetworkResult
 import javax.inject.Inject
 
 class GetUserDetailsUseCase @Inject constructor(private val repository: MainRepository) {
-    suspend operator fun invoke(userName: String): NetworkResult<GithubUser> =
-        repository.getUserDetails(userName)
+    suspend operator fun invoke(userName: String): DomainResult<GithubUser> {
+        return when (val networkResult = repository.getUserDetails(userName)) {
+            is NetworkResult.Success -> DomainResult.Success(networkResult.result)
+            is NetworkResult.Error -> DomainResult.Error(networkResult.exception.message ?: "Unknown error")
+        }
+    }
 }

--- a/features/main/src/main/java/xyz/androidrey/githubclient/main/domain/usecase/users/GetUsersListWithCacheUseCase.kt
+++ b/features/main/src/main/java/xyz/androidrey/githubclient/main/domain/usecase/users/GetUsersListWithCacheUseCase.kt
@@ -1,10 +1,16 @@
 package xyz.androidrey.githubclient.main.domain.usecase.users
 
 import xyz.androidrey.githubclient.common.data.entity.user.User
+import xyz.androidrey.githubclient.common.domain.model.DomainResult
 import xyz.androidrey.githubclient.main.domain.repository.MainRepository
 import xyz.androidrey.githubclient.network.NetworkResult
 import javax.inject.Inject
 
 class GetUsersListWithCacheUseCase @Inject constructor(private val repository: MainRepository) {
-    suspend operator fun invoke(): NetworkResult<List<User>> = repository.getUsersListWithCache()
+    suspend operator fun invoke(): DomainResult<List<User>> {
+        return when (val networkResult = repository.getUsersListWithCache()) {
+            is NetworkResult.Success -> DomainResult.Success(networkResult.result)
+            is NetworkResult.Error -> DomainResult.Error(networkResult.exception.message ?: "Unknown error")
+        }
+    }
 }

--- a/features/main/src/main/java/xyz/androidrey/githubclient/main/ui/userlist/UsersScreen.kt
+++ b/features/main/src/main/java/xyz/androidrey/githubclient/main/ui/userlist/UsersScreen.kt
@@ -38,14 +38,14 @@ import xyz.androidrey.githubclient.theme.components.TheTextField
 fun UserList(
     users: List<User>,
     query: String,
-    viewModel: UsersViewModel,
+    onQueryChanged: (String) -> Unit,
     onSelect: (String) -> Unit
 ) {
     Column {
         // 🛠️ Static top search bar
         TheTextField(
             value = query,
-            onValueChanged = { viewModel.updateSearchQuery(it) },
+            onValueChanged = { onQueryChanged(it) },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 12.dp),

--- a/features/main/src/main/java/xyz/androidrey/githubclient/main/ui/userlist/UsersViewModel.kt
+++ b/features/main/src/main/java/xyz/androidrey/githubclient/main/ui/userlist/UsersViewModel.kt
@@ -15,12 +15,12 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import xyz.androidrey.githubclient.common.data.entity.user.User
+import xyz.androidrey.githubclient.common.domain.model.DomainResult
 import xyz.androidrey.githubclient.common.ui.state.UiState
 import xyz.androidrey.githubclient.main.domain.repository.MainRepository
 import xyz.androidrey.githubclient.main.domain.usecase.users.GetCachedUsersUseCase
 import xyz.androidrey.githubclient.main.domain.usecase.users.GetUsersListWithCacheUseCase
 import xyz.androidrey.githubclient.main.domain.usecase.users.SearchCachedUsersUseCase
-import xyz.androidrey.githubclient.network.NetworkResult
 import javax.inject.Inject
 
 @HiltViewModel
@@ -58,12 +58,12 @@ class UsersViewModel @Inject constructor(
         _uiState.value = UiState.Loading
         viewModelScope.launch {
             when (val result = getUsersListWithCacheUseCase.invoke()) {
-                is NetworkResult.Success -> {
-                    _uiState.value = UiState.Success(result.result)
+                is DomainResult.Success -> {
+                    _uiState.value = UiState.Success(result.data)
                 }
 
-                is NetworkResult.Error -> {
-                    _uiState.value = UiState.Error(result.exception.message ?: "Unknown error")
+                is DomainResult.Error -> {
+                    _uiState.value = UiState.Error(result.message)
                 }
             }
         }

--- a/features/main/src/main/java/xyz/androidrey/githubclient/main/ui/userrepository/UserRepositoryScreen.kt
+++ b/features/main/src/main/java/xyz/androidrey/githubclient/main/ui/userrepository/UserRepositoryScreen.kt
@@ -42,13 +42,12 @@ import xyz.androidrey.githubclient.theme.components.placeholder.RepositoryLoadin
 @Composable
 fun UserRepositoryScreen(
     userName: String?,
-    viewModel: UserRepositoryViewModel,
+    uiState: xyz.androidrey.githubclient.common.ui.state.UiState<Pair<GithubUser, List<Repository>>>,
+    onLoad: () -> Unit,
     navController: NavHostController
 ) {
-    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
     LaunchedEffect(userName) {
-        viewModel.load()
+        onLoad()
     }
 
     UiStateHandler(

--- a/features/main/src/test/java/xyz/androidrey/githubclient/main/ui/userlist/UsersViewModelTest.kt
+++ b/features/main/src/test/java/xyz/androidrey/githubclient/main/ui/userlist/UsersViewModelTest.kt
@@ -14,13 +14,12 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
+import xyz.androidrey.githubclient.common.domain.model.DomainResult
 import xyz.androidrey.githubclient.common.ui.state.UiState
 import xyz.androidrey.githubclient.main.data.repository.createDummyUsers
 import xyz.androidrey.githubclient.main.domain.usecase.users.GetCachedUsersUseCase
 import xyz.androidrey.githubclient.main.domain.usecase.users.GetUsersListWithCacheUseCase
 import xyz.androidrey.githubclient.main.domain.usecase.users.SearchCachedUsersUseCase
-import xyz.androidrey.githubclient.network.NetworkException
-import xyz.androidrey.githubclient.network.NetworkResult
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -56,7 +55,7 @@ class UsersViewModelTest {
     @Test
     fun `initial uiState should emit Success when API returns users`() = runTest {
         // Arrange
-        coEvery { getUsersListWithCacheUseCase() } returns NetworkResult.Success(users)
+        coEvery { getUsersListWithCacheUseCase() } returns DomainResult.Success(users)
         coEvery { getCachedUsersUseCase() } returns users
         coEvery { searchCachedUsersUseCase(any()) } returns flowOf(users)
 
@@ -76,10 +75,7 @@ class UsersViewModelTest {
 
     @Test
     fun `initial uiState should emit Error when API fails and no cache`() = runTest {
-        coEvery { getUsersListWithCacheUseCase() } returns NetworkResult.Error(
-            exception = NetworkException.UnknownException("Network failed", Throwable()),
-            body = "Network failed"
-        )
+        coEvery { getUsersListWithCacheUseCase() } returns DomainResult.Error("Network failed")
         coEvery { getCachedUsersUseCase() } returns emptyList()
         coEvery { searchCachedUsersUseCase(any()) } returns flowOf(emptyList())
 
@@ -97,7 +93,7 @@ class UsersViewModelTest {
 
     @Test
     fun `updateSearchQuery should change searchQuery value`() = runTest {
-        coEvery { getUsersListWithCacheUseCase() } returns NetworkResult.Success(users)
+        coEvery { getUsersListWithCacheUseCase() } returns DomainResult.Success(users)
         coEvery { getCachedUsersUseCase() } returns users
         coEvery { searchCachedUsersUseCase(any()) } returns flowOf(users)
 
@@ -115,7 +111,7 @@ class UsersViewModelTest {
     fun `searchedUsers should emit filtered users when query is not blank`() = runTest {
         val filtered = users.filter { it.login.contains("dev") }
 
-        coEvery { getUsersListWithCacheUseCase() } returns NetworkResult.Success(users)
+        coEvery { getUsersListWithCacheUseCase() } returns DomainResult.Success(users)
         coEvery { getCachedUsersUseCase() } returns users
         coEvery { searchCachedUsersUseCase("dev") } returns flowOf(filtered)
 

--- a/features/main/src/test/java/xyz/androidrey/githubclient/main/ui/userrepository/UserRepositoryViewModelTest.kt
+++ b/features/main/src/test/java/xyz/androidrey/githubclient/main/ui/userrepository/UserRepositoryViewModelTest.kt
@@ -1,0 +1,153 @@
+package xyz.androidrey.githubclient.main.ui.userrepository
+
+import androidx.lifecycle.ViewModelProvider
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.verify
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import xyz.androidrey.githubclient.common.data.entity.githubuser.GithubUser
+import xyz.androidrey.githubclient.common.data.entity.repository.Repository
+import xyz.androidrey.githubclient.common.domain.model.DomainResult
+import xyz.androidrey.githubclient.common.ui.state.UiState
+import xyz.androidrey.githubclient.main.domain.usecase.repository.GetRepositoryUseCase
+import xyz.androidrey.githubclient.main.domain.usecase.users.GetUserDetailsUseCase
+
+@ExperimentalCoroutinesApi
+class UserRepositoryViewModelTest {
+
+    private lateinit var getUserDetailsUseCase: GetUserDetailsUseCase
+    private lateinit var getRepositoryUseCase: GetRepositoryUseCase
+    private lateinit var viewModel: UserRepositoryViewModel
+    private lateinit var viewModelFactory: UserRepositoryViewModel.Factory
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testUserName = "testUser"
+
+    private val dummyUser = GithubUser(login = testUserName, id = 1, avatarUrl = "", name = "Test User", followers = 0, following = 0)
+    private val dummyRepos = listOf(
+        Repository(id = 1, name = "Repo1", description = "Desc1", stargazersCount = 10, language = "Kotlin", htmlUrl = "", fork = false),
+        Repository(id = 2, name = "Repo2", description = "Desc2", stargazersCount = 20, language = "Java", htmlUrl = "", fork = true) // Forked repo
+    )
+    private val nonForkedRepos = dummyRepos.filter { !it.fork }
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        getUserDetailsUseCase = mockk()
+        getRepositoryUseCase = mockk()
+        // Mock the AssistedFactory for UserRepositoryViewModel
+        viewModelFactory = mockk {
+            coEvery { create(testUserName) } answers {
+                UserRepositoryViewModel(getUserDetailsUseCase, getRepositoryUseCase, testUserName)
+            }
+        }
+        viewModel = viewModelFactory.create(testUserName)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `load WHEN use cases return success THEN uiState is Success with user and non-forked repos`() = runTest {
+        coEvery { getUserDetailsUseCase(testUserName) } returns DomainResult.Success(dummyUser)
+        coEvery { getRepositoryUseCase(testUserName) } returns DomainResult.Success(dummyRepos)
+
+        viewModel.load() // Trigger loading
+        advanceUntilIdle() // Let coroutines complete
+
+        val state = viewModel.uiState.value
+        assertTrue(state is UiState.Success)
+        assertEquals(dummyUser, (state as UiState.Success).data.first)
+        assertEquals(nonForkedRepos, state.data.second)
+    }
+
+    @Test
+    fun `load WHEN getUserDetailsUseCase returns error THEN uiState is Error`() = runTest {
+        val errorMessage = "Failed to fetch user"
+        coEvery { getUserDetailsUseCase(testUserName) } returns DomainResult.Error(errorMessage)
+        coEvery { getRepositoryUseCase(testUserName) } returns DomainResult.Success(dummyRepos)
+
+        viewModel.load()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state is UiState.Error)
+        assertEquals(errorMessage, (state as UiState.Error).message)
+    }
+
+    @Test
+    fun `load WHEN getRepositoryUseCase returns error THEN uiState is Error`() = runTest {
+        val errorMessage = "Failed to fetch repositories"
+        coEvery { getUserDetailsUseCase(testUserName) } returns DomainResult.Success(dummyUser)
+        coEvery { getRepositoryUseCase(testUserName) } returns DomainResult.Error(errorMessage)
+
+        viewModel.load()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state is UiState.Error)
+        assertEquals(errorMessage, (state as UiState.Error).message)
+    }
+    
+    @Test
+    fun `load WHEN both use cases return error THEN uiState is Error with user error message`() = runTest {
+        val userErrorMessage = "User fetch failed"
+        val repoErrorMessage = "Repo fetch failed"
+        coEvery { getUserDetailsUseCase(testUserName) } returns DomainResult.Error(userErrorMessage)
+        coEvery { getRepositoryUseCase(testUserName) } returns DomainResult.Error(repoErrorMessage)
+
+        viewModel.load()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state is UiState.Error)
+        assertEquals(userErrorMessage, (state as UiState.Error).message) // viewModel prioritizes user error
+    }
+
+    @Test
+    fun `load multiple times only fetches once`() = runTest {
+        coEvery { getUserDetailsUseCase(testUserName) } returns DomainResult.Success(dummyUser)
+        coEvery { getRepositoryUseCase(testUserName) } returns DomainResult.Success(dummyRepos)
+
+        viewModel.load()
+        viewModel.load() // Call load again
+        advanceUntilIdle()
+        
+        verify(exactly = 1) { getUserDetailsUseCase(testUserName) }
+        verify(exactly = 1) { getRepositoryUseCase(testUserName) }
+    }
+    
+    @Test
+    fun `initial state is Loading before load is called and completes`() = runTest {
+         // Re-create ViewModel for this specific test to check initial state before load() is manually called
+         val freshViewModel = viewModelFactory.create(testUserName)
+         assertTrue(freshViewModel.uiState.value is UiState.Loading) // State right after creation
+
+         // Mock calls for the subsequent load
+         coEvery { getUserDetailsUseCase(testUserName) } returns DomainResult.Success(dummyUser)
+         coEvery { getRepositoryUseCase(testUserName) } returns DomainResult.Success(dummyRepos)
+         
+         freshViewModel.load()
+         // Before advanceUntilIdle, it might still be Loading or already moved to Success quickly
+         // Depending on dispatcher, it could be Loading or Success.
+         // For more deterministic check of intermediate Loading state:
+         // val intermediateState = freshViewModel.uiState.value 
+         // assertTrue(intermediateState is UiState.Loading) // This might be true if load() sets it synchronously
+
+         advanceUntilIdle() // Let load complete
+         assertTrue(freshViewModel.uiState.value is UiState.Success)
+    }
+}


### PR DESCRIPTION
This commit applies several changes to align the view and ViewModel layers more closely with Clean Architecture principles:

1.  **Introduced DomainResult**:
    *   A new `DomainResult<T>` sealed class (Success, Error) was added to the common module.
    *   Use cases (`GetUsersListWithCacheUseCase`, `GetUserDetailsUseCase`, `GetRepositoryUseCase`) were refactored to return `DomainResult` instead of the data layer's `NetworkResult`. This decouples the domain layer from data-specific result types.

2.  **ViewModel Updates**:
    *   `UsersViewModel` and `UserRepositoryViewModel` were updated to consume `DomainResult` from their respective use cases.
    *   They now map `DomainResult` to `UiState` (Success/Error), handling the presentation logic.

3.  **Passive Views (Composables)**:
    *   `UserList` composable (in `UsersScreen.kt`) was modified to accept specific data parameters and an `onQueryChanged` lambda, instead of the entire `UsersViewModel`.
    *   `UserRepositoryScreen` composable was modified to accept `uiState` and an `onLoad` lambda, instead of the entire `UserRepositoryViewModel`.
    *   Call sites for these composables were updated accordingly in `UserListWithDetailsScreen.kt`. This makes the views more passive, easier to test, and less coupled to ViewModel implementations.

4.  **Unit Test Enhancements**:
    *   `UsersViewModelTest.kt` was updated to align with the `DomainResult` changes in its mocked use cases.
    *   A new `UserRepositoryViewModelTest.kt` was created, providing comprehensive test coverage for `UserRepositoryViewModel`, including success states, various error conditions, and interaction with its use cases returning `DomainResult`.

These changes improve separation of concerns, testability, and maintainability of the UI and domain interaction logic.